### PR TITLE
fix to let tidebot deploy tide-whisperer

### DIFF
--- a/scripts/kubernetes.coffee
+++ b/scripts/kubernetes.coffee
@@ -179,6 +179,8 @@ module.exports = (robot) ->
                             console.log "Updating cluster values.yaml"
                             services = repoToServices()
                             for service in services
+                                if service == "tide-whisperer"
+                                   service = "tidewhisperer"
                                 if match[1] == "default"
                                    delete document.namespaces[config.Namespace][config.Service].gitops[service]
                                 else


### PR DESCRIPTION
Tidebot tries to edit values.yaml setting the key "tide-whisperer",
which it retrieves from the name of the repository. Flux however, is
expecting "tidewhisperer", which was manually specified, I presume to
avoid names with -'s, which don't make good JSON keys.
